### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Chroma MCP Server
+[![smithery badge](https://smithery.ai/badge/chroma)](https://smithery.ai/server/chroma)
 
 A Model Context Protocol (MCP) server implementation that provides vector database capabilities through Chroma. This server enables semantic document search, metadata filtering, and document management with persistent storage.
 
@@ -64,6 +65,16 @@ The server implements CRUD operations and search functionality:
 - **Retry Logic**: Automatic retries for transient failures
 
 ## Installation
+
+### Installing via Smithery
+
+To install Chroma for Claude Desktop automatically via [Smithery](https://smithery.ai/server/chroma):
+
+```bash
+npx -y @smithery/cli install chroma --client claude
+```
+
+### Manual Installation
 
 1. Install dependencies:
 ```bash


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Chroma for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/chroma

Let me know if any tweaks have to be made!